### PR TITLE
Potential fix for code scanning alert no. 6: Database query built from user-controlled sources

### DIFF
--- a/backend/src/controllers/collectionController.js
+++ b/backend/src/controllers/collectionController.js
@@ -8,14 +8,15 @@ class CollectionController {
       const { name, description, isPublic, category, color, tags } = req.body;
       const userId = req.user.id;
 
-      if (!name) {
+      if (typeof name !== "string" || !name.trim()) {
         throw new ApiError("Collection name is required", 400);
       }
+      const normalizedName = name.trim();
 
       // Check if collection with same name already exists for this user
       const existingCollection = await BookCollection.findOne({
         user: userId,
-        name,
+        name: { $eq: normalizedName },
       });
       if (existingCollection) {
         throw new ApiError("Collection with this name already exists", 400);
@@ -23,7 +24,7 @@ class CollectionController {
 
       const newCollection = await BookCollection.create({
         user: userId,
-        name,
+        name: normalizedName,
         description,
         isPublic: !!isPublic,
         category: category || "general",


### PR DESCRIPTION
Potential fix for [https://github.com/DrDevEli/bookpath-app/security/code-scanning/6](https://github.com/DrDevEli/bookpath-app/security/code-scanning/6)

Use defensive input validation plus a literal comparison operator in the query.

Best fix here (without changing functionality): in `createCollection` (around lines 8–19), validate that `name` is a non-empty string, normalize it with `trim()`, and then use `$eq` in the `findOne` filter:
- Reject non-string `name` with `ApiError(400)`.
- Keep current required-name behavior.
- Replace `name` in the query with `name: { $eq: normalizedName }`.
- Use the normalized name when creating the collection so duplicate checks and stored value stay consistent.

This change is limited to `backend/src/controllers/collectionController.js` and needs no new imports or dependencies.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
