### PR TITLE
Potential fix for code scanning alert no. 3: Database query built from user-controlled sources

### DIFF
--- a/backend/src/controllers/emailVerificationController.js
+++ b/backend/src/controllers/emailVerificationController.js
@@ -95,7 +95,12 @@ export async function verifyEmail(token) {
  */
 export async function resendVerificationEmail(email) {
   try {
-    const user = await User.findOne({ email });
+    if (typeof email !== "string" || email.trim() === "") {
+      throw new ApiError("Email is required", 400);
+    }
+
+    const normalizedEmail = email.trim();
+    const user = await User.findOne({ email: normalizedEmail });
 
     if (!user) {
       throw new ApiError("User not found", 404);
@@ -137,13 +142,13 @@ export async function resendVerificationEmailHandler(req, res, next) {
   try {
     const email = req.user?.email || req.body?.email;
 
-    if (!email) {
+    if (typeof email !== "string" || email.trim() === "") {
       return res
         .status(400)
         .json({ success: false, message: "Email is required" });
     }
 
-    await resendVerificationEmail(email);
+    await resendVerificationEmail(email.trim());
 
     res.status(200).json({
       success: true,

--- a/backend/src/routes/authRoutes.js
+++ b/backend/src/routes/authRoutes.js
@@ -337,14 +337,14 @@ router.post(
     try {
       const { email } = req.body;
 
-      if (!email) {
+      if (typeof email !== "string" || email.trim() === "") {
         return res.status(400).json({
           success: false,
           message: "Email is required",
         });
       }
 
-      await emailVerificationController.resendVerificationEmail(email);
+      await emailVerificationController.resendVerificationEmail(email.trim());
 
       res.status(200).json({
         success: true,


### PR DESCRIPTION
Potential fix for [https://github.com/DrDevEli/bookpath-app/security/code-scanning/3](https://github.com/DrDevEli/bookpath-app/security/code-scanning/3)

The best fix is to ensure `email` is a literal string before it is used in `User.findOne`, and reject anything else. This prevents query-object/operator injection while preserving existing behavior for valid emails.

Single best approach here (minimal functional change):
1. In `backend/src/controllers/emailVerificationController.js`, harden `resendVerificationEmail(email)` by validating:
   - `typeof email === "string"`
   - non-empty after trim
2. Use the normalized string in the query.
3. (Optional but good defense-in-depth in the same file) Add equivalent strict checks in `resendVerificationEmailHandler` before passing to service logic.
4. In `backend/src/routes/authRoutes.js`, in `/resend-verification-public`, validate `req.body.email` is a non-empty string and pass trimmed value onward.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes input validation and error behavior in an authentication-adjacent endpoint, but the functional change is narrowly scoped to rejecting non-string/blank inputs.
> 
> **Overview**
> Tightens the resend verification email flow to mitigate query/operator injection by **requiring `email` to be a non-empty string** and using a **trimmed/normalized value** for the `User.findOne` lookup.
> 
> Applies the same validation/normalization in both the authenticated handler (`resendVerificationEmailHandler`) and the public route (`/resend-verification-public`) so only sanitized string emails reach the controller logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cc9e52f4b5ecb97fe87d0b4a9bb4e08f75f0f14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->