### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/backend/src/services/googleBooksService.js
+++ b/backend/src/services/googleBooksService.js
@@ -156,10 +156,9 @@ export async function getGoogleBookById(volumeId) {
         }
         if (response.status === 403) {
           const errorText = await response.text().catch(() => '');
-          logger.error("Google Books API 403 Forbidden", { 
+          logger.error("Google Books API 403 Forbidden", {
             error: errorText,
-            hasApiKey: !!apiKey,
-            apiKeyLength: apiKey ? apiKey.length : 0
+            reason: "access_denied"
           });
           throw new ApiError(
             "Google Books API access denied. Please check API key configuration and restrictions.",


### PR DESCRIPTION
Potential fix for [https://github.com/DrDevEli/bookpath-app/security/code-scanning/2](https://github.com/DrDevEli/bookpath-app/security/code-scanning/2)

General fix approach: remove sensitive (or secret-derived) fields from structured logs, and keep only minimal non-sensitive diagnostics needed for troubleshooting.

Best fix here: in `backend/src/services/googleBooksService.js`, update the 403 logging block inside `getGoogleBookById` so it no longer logs `apiKeyLength` (and preferably not `hasApiKey` either). Keep a safe log payload such as a generic reason plus optional sanitized upstream error text. This preserves behavior (still logs and still throws the same `ApiError`) while eliminating clear-text logging of secret-derived data.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts structured logging on Google Books 403 responses and leaves request/exception behavior unchanged.
> 
> **Overview**
> Redacts potentially sensitive, API key–derived details from the `getGoogleBookById` 403 error log in `googleBooksService.js` by removing `hasApiKey`/`apiKeyLength` and logging a minimal `reason` plus the upstream error text.
> 
> Error handling behavior is otherwise unchanged (still logs and throws the same 403 `ApiError`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a87cd67ce5eeb6018dfdbfc0cd9817fa974040d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->