### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/backend/src/services/googleBooksService.js
+++ b/backend/src/services/googleBooksService.js
@@ -62,10 +62,9 @@ export async function searchGoogleBooks({ title, author, subject, page = 1 }) {
       if (!response.ok) {
         if (response.status === 403) {
           const errorText = await response.text().catch(() => '');
-          logger.error("Google Books API 403 Forbidden", { 
-            error: errorText,
-            hasApiKey: !!apiKey,
-            apiKeyLength: apiKey ? apiKey.length : 0
+          logger.error("Google Books API 403 Forbidden", {
+            hasErrorBody: Boolean(errorText),
+            status: response.status
           });
           throw new ApiError(
             "Google Books API access denied. Please check API key configuration and restrictions.",


### PR DESCRIPTION
Potential fix for [https://github.com/DrDevEli/bookpath-app/security/code-scanning/1](https://github.com/DrDevEli/bookpath-app/security/code-scanning/1)

To fix this, stop logging any value derived from `apiKey` (including existence and length). Keep only non-sensitive diagnostics such as HTTP status and a generic message.

Best single fix in `backend/src/services/googleBooksService.js`:
- In the `response.status === 403` block, replace the `logger.error(...)` metadata object so it no longer includes:
  - `hasApiKey`
  - `apiKeyLength`
- Also avoid logging full upstream response bodies (`errorText`) because they may include sensitive details from external services. Log only a safe, generic indicator (e.g., `hasErrorBody`).

This keeps functionality unchanged (same control flow, same thrown error) while removing clear-text sensitive logging.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts error logging metadata for Google Books 403 responses and does not change request/response control flow.
> 
> **Overview**
> Redacts potentially sensitive details from Google Books 403 error logs by removing API key–derived fields and the raw upstream error body, replacing them with safe diagnostics (`status` and a `hasErrorBody` flag).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff20a32f01c315d7c8e7561dcc759e0066676ed6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->